### PR TITLE
All the misc fixes

### DIFF
--- a/config/darkmodeeverywhere-client.toml
+++ b/config/darkmodeeverywhere-client.toml
@@ -1,0 +1,30 @@
+#A list of class:method strings (render methods) that the dark shader will not be applied to.
+#Each string consists of the class and the method (or any substring) to block the dark shader.
+#For example, 'renderHunger' is sufficient to block 'net.minecraftforge.client.gui.overlay.ForgeGui:renderFood' (either will work).
+METHOD_SHADER_BLACKLIST = ["mezz.jei.common.render.FluidTankRenderer:drawTextureWithMasking", "mezz.jei.library.render.FluidTankRenderer:drawTextureWithMasking", "renderCrosshair", "m_93080_", "renderSky", "m_202423_", "renderHotbar", "m_93009_", "m_193837_", "setupOverlayRenderState", "net.minecraftforge.client.gui.overlay.ForgeGui", "renderFood", "renderExperienceBar", "m_93071_", "renderLogo", "m_280037_", "m_280118_", "net.minecraft.client.gui.Gui", "net.minecraft.src.C_3431_", "renderDirtBackground", "m_280039_", "m_280039_", "configured.client.screen.ListMenuScreen", "OnlineServerEntry:drawIcon", "OnlineServerEntry:m_99889_", "WorldSelectionList$WorldListEntry:render", "WorldSelectionList$WorldListEntry:m_6311_", "CubeMap:render", "CubeMap:m_108849_", "squeek.appleskin.client.HUDOverlayHandler", "shadows.packmenu.ExtendedMenuScreen"]
+#Enabling this config will (every 5 seconds) dump which methods were used to render GUIs that the dark shader was applied to
+#The dump will consist of a list of class:method strings, e.g. 'net.minecraftforge.client.gui.overlay.ForgeGui:renderFood'
+#Use this feature to help find the render method strings of GUIs you would like to blacklist.
+METHOD_SHADER_DUMP = false
+
+["Inventory Button"]
+	#Pixels away from the left of the GUI in the x axis
+	# Default: 32
+	# Range: > 0
+	X = 30
+	#Pixels away from the bottom of the GUI in the y axis
+	# Default: 2
+	# Range: > 0
+	Y = 7
+
+["Main Menu Button"]
+	#Enabled
+	SHOW = false
+	#Pixels away from the left of the GUI in the x axis
+	# Default: 4
+	# Range: > 0
+	MAIN_X = 4
+	#Pixels away from the bottom of the GUI in the y axis
+	# Default: 40
+	# Range: > 0
+	MAIN_Y = 40

--- a/kubejs/server_scripts/mods/forbidden_arcanus/hephaestus_forge.js
+++ b/kubejs/server_scripts/mods/forbidden_arcanus/hephaestus_forge.js
@@ -1,0 +1,175 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.generateData('after_mods', function (allthemods) {
+
+    /**
+     * @param {string} value
+     * @returns {{item: string}|{tag: string}}
+     */
+    function ingredientOf (value) {
+        if (typeof value === 'string') {
+            if (value.charAt(0) === '#') {
+                return { tag: value.substring(1) }
+            }
+            return { item: value }
+        }
+    }
+
+    /**
+     * @readonly
+     * @enum {string}
+     */
+    const Essences = {
+        Aureal:     "aureal",
+        Blood:      "blood",
+        Souls:      "souls",
+        Experience: "experience"
+    }
+    
+    function HephaestusRecipe(result, amount, magicCircle) {
+        this._result = { item: result, count: amount }
+        this._magicCircle = magicCircle
+        this._tier = 0
+        this._ingredients = []
+        this._catalyst = null
+        this._essences = {
+            Aureal: 0,
+            Blood: 0,
+            Souls: 0,
+            Experience: 0
+        }
+    }
+
+    HephaestusRecipe.prototype = {
+        /**
+         * @description Tier of the forge, must be between 1 and 5 (inclusive).
+         * @param {number} tier
+         */
+        tier: function (tier) {
+            this._tier = tier
+            return this
+        },
+        /**
+         * @description Either item 'minecraft:item' or tag '#minecraft:tag'.
+         * @param {string} value
+         */
+        catalyst: function (value) {
+            this._catalyst = ingredientOf(value)
+            return this
+        },
+        /**
+         * @description Either item 'minecraft:item' or tag '#minecraft:tag' and the respective amount.
+         * @param {string} value
+         * @param {number} amount
+         */
+        ingredient: function (value, amount) {
+            let amt = (amount != null ? amount : 1)
+            let ing = ingredientOf(value)
+            this._ingredients.push({ ingredient: ing, amount: amt })
+            return this
+        },
+        /**
+         * @description Amount of essences of this type to be used in the recipe.
+         * @param {Essences} value
+         * @param {number} amount
+         */
+        essence: function (value, amount) {
+            this._essences[value] = amount
+            return this
+        },
+        /**
+         * @description Build the recipe.
+         * @param {$KubeDataGenerator} allthemods
+         */
+        build(allthemods) {
+            if (this._result.item == null || this._result.count < 1) {
+                throw new Error('Result item must exist and count must be greater than 0')
+            }
+            if (this._tier < 1 || this._tier > 5) {
+                throw new Error('Forge tier must be between 1 and 5 (inclusive)')
+            }
+            if (this._catalyst == null) {
+                throw new Error('Main Ingredient (Catalyst) must exist')
+            }
+            if (this._ingredients.length < 1 || this._ingredients.length > 8) {
+                throw new Error('At least 1 ingredient and no more than 8 ingredients are required')
+            }
+            allthemods.json('allthemods:forbidden_arcanus/hephaestus_forge/ritual/' + this._result.item.split(':').pop() + '.json', {
+                essences: this._essences,
+                forge_tier: this._tier,
+                inputs: this._ingredients,
+                magic_circle: this._magicCircle,
+                main_ingredient: this._catalyst,
+                result: {
+                    type: 'forbidden_arcanus:create_item',
+                    result_item: {
+                        count: this._result.count,
+                        id: this._result.item
+                    }
+                }
+            })
+        }
+    }
+
+    function create_item(result, amount) {
+        return new HephaestusRecipe(result, amount, 'forbidden_arcanus:create_item')
+    }
+
+    function upgrade_item(result, amount) {
+        return new HephaestusRecipe(result, amount, 'forbidden_arcanus:upgrade_tier')
+    }
+    
+    
+    create_item('forbidden_arcanus:elementarium', 1)
+        .tier(3)
+        .essence(Essences.Aureal, 180)
+        .essence(Essences.Blood, 200)
+        .essence(Essences.Souls, 3)
+        .catalyst('forbidden_arcanus:eternal_stella')
+        .ingredient('forbidden_arcanus:dragon_scale', 1)
+        .ingredient('forbidden_arcanus:arcane_crystal_dust', 1)
+        .ingredient('forbidden_arcanus:golden_dragon_scale', 1)
+        .ingredient('forbidden_arcanus:arcane_crystal_dust', 1)
+        .ingredient('forbidden_arcanus:silver_dragon_scale', 1)
+        .ingredient('forbidden_arcanus:arcane_crystal_dust', 1)
+        .ingredient('forbidden_arcanus:aquatic_dragon_scale', 1)
+        .ingredient('forbidden_arcanus:arcane_crystal_dust', 1)
+        .build(allthemods)
+
+    create_item('forbidden_arcanus:artisan_relic', 1)
+        .tier(3)
+        .essence(Essences.Aureal, 150)
+        .essence(Essences.Blood, 300)
+        .essence(Essences.Souls, 4)
+        .catalyst('create:blaze_burner')
+        .ingredient('justdirethings:blazegold_ingot', 1)
+        .ingredient('reliquary:molten_core', 1)
+        .ingredient('justdirethings:blazegold_ingot', 1)
+        .ingredient('minecraft:obsidian', 1)
+        .ingredient('justdirethings:blazegold_ingot', 1)
+        .ingredient('minecraft:obsidian', 1)
+        .ingredient('justdirethings:blazegold_ingot', 1)
+        .ingredient('reliquary:molten_core', 1)
+        .build(allthemods)
+
+    create_item('forbidden_arcanus:divine_pact', 1)
+        .tier(3)
+        .essence(Essences.Aureal, 400)
+        .essence(Essences.Blood, 120)
+        .essence(Essences.Souls, 8)
+        .catalyst('forbidden_arcanus:eternal_stella')
+        .ingredient('forbidden_arcanus:quantum_core', 1)
+        .ingredient('irons_spellbooks:holy_rune', 1)
+        .ingredient('forbidden_arcanus:quantum_core', 1)
+        .ingredient('irons_spellbooks:holy_rune', 1)
+        .ingredient('forbidden_arcanus:quantum_core', 1)
+        .ingredient('irons_spellbooks:holy_rune', 1)
+        .ingredient('forbidden_arcanus:quantum_core', 1)
+        .ingredient('irons_spellbooks:holy_rune', 1)
+        .build(allthemods)
+    
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/mods/industrial_foregoing/laser_drill.js
+++ b/kubejs/server_scripts/mods/industrial_foregoing/laser_drill.js
@@ -1,0 +1,52 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+
+    /**
+     * @param {{tag: string, count: number}} output
+     * @param {string} catalyst
+     * @param {number} depthMin
+     * @param {number} depthMax
+     * @param {number} weight
+     */
+    function laserDrillOre(output, catalyst, depthMin, depthMax, weight) {
+        allthemods
+            .custom({
+                type: 'industrialforegoing:laser_drill_ore',
+                output: {
+                    tag: output.tag,
+                    count: output.count || 1
+                },
+                rarity: [
+                    {
+                        biome_filter: {
+                            whitelist:  [],
+                            blacklist:  [],
+                        },
+                        dimension_filter: {
+                            whitelist:  [],
+                            blacklist:  [],
+                        },
+                        depth_min:  depthMin,
+                        depth_max:  depthMax,
+                        weight:     weight
+                    }
+                ],
+                catalyst: {
+                    item: catalyst
+                }
+            })
+            .id(`allthemods:industrialforegoing/laser_drill_ore/${output.tag.split(':')[1]}`);
+    }
+    
+    laserDrillOre(
+        {tag: 'c:gems/benitoite', count: 8},
+        'industrialforegoing:blue_laser_lens',
+        5, 256, 5
+    );
+    
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -160,6 +160,17 @@ ServerEvents.recipes(allthemods => {
             N: '#c:nuggets/iron',
         }
     )
+
+    allthemods.remove({id: 'handcrafted:wood_plate'})
+    allthemods.shaped(
+        Item.of('handcrafted:wood_plate'),
+        [
+            'SSS',
+            ' S '
+        ], {
+            S: '#minecraft:wooden_slabs',
+        }
+    )
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -171,6 +171,19 @@ ServerEvents.recipes(allthemods => {
             S: '#minecraft:wooden_slabs',
         }
     )
+
+    allthemods.remove({id: 'handcrafted:hammer'})
+    allthemods.shaped(
+        Item.of('handcrafted:hammer'),
+        [
+            ' IS',
+            ' SI',
+            'S  '
+        ], {
+            S: '#c:rods/wooden',
+            I: '#c:ingots/iron',
+        }
+    )
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -147,6 +147,19 @@ ServerEvents.recipes(allthemods => {
             '#c:leathers'
         ]
     ).id('minecraft:book')
+    
+    allthemods.remove({id: 'enderio:wood_gear'})
+    allthemods.shaped(
+        Item.of('enderio:wood_gear'),
+        [
+            ' S ',
+            'SNS',
+            ' S '
+        ], {
+            S: '#c:rods/wooden',
+            N: '#c:nuggets/iron',
+        }
+    )
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -184,6 +184,18 @@ ServerEvents.recipes(allthemods => {
             I: '#c:ingots/iron',
         }
     )
+
+    allthemods.remove({id: 'mcwwindows:bamboo_shutter'})
+    allthemods.shaped(
+        Item.of('mcwwindows:bamboo_shutter'),
+        [
+            'BB',
+            'BB',
+            'BB'
+        ], {
+            B: 'minecraft:bamboo',
+        }
+    )
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -138,6 +138,15 @@ ServerEvents.recipes(allthemods => {
             'B': '#c:storage_blocks/unobtainium'
         }
     )
+    
+    allthemods.remove({id: 'minecraft:book'})
+    allthemods.shapeless(
+        Item.of('minecraft:book'),
+        [
+            '3x #c:paper',
+            '#c:leathers'
+        ]
+    ).id('minecraft:book')
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -196,6 +196,9 @@ ServerEvents.recipes(allthemods => {
             B: 'minecraft:bamboo',
         }
     )
+
+    allthemods.remove({id: 'mysticalagriculture:watering_can'})
+    allthemods.remove({id: 'mysticalagriculture:diamond_scythe'})
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -102,6 +102,42 @@ ServerEvents.recipes(allthemods => {
             'N': 'minecraft:nautilus_shell',
         }
     )
+
+    allthemods.shaped(
+        Item.of('allthemodium:allthemodium_upgrade_smithing_template'), [
+            'ITI',
+            'IBI',
+            'III'
+        ], {
+            'I': '#c:ingots/netherite',
+            'T': 'minecraft:netherite_upgrade_smithing_template',
+            'B': '#c:storage_blocks/allthemodium'
+        }
+    )
+
+    allthemods.shaped(
+        Item.of('allthemodium:vibranium_upgrade_smithing_template'), [
+            'ITI',
+            'IBI',
+            'III'
+        ], {
+            'I': '#c:ingots/allthemodium',
+            'T': 'allthemodium:allthemodium_upgrade_smithing_template',
+            'B': '#c:storage_blocks/vibranium'
+        }
+    )
+
+    allthemods.shaped(
+        Item.of('allthemodium:unobtainium_upgrade_smithing_template'), [
+            'ITI',
+            'IAI',
+            'III'
+        ], {
+            'I': '#c:ingots/vibranium',
+            'T': 'allthemodium:vibranium_upgrade_smithing_template',
+            'B': '#c:storage_blocks/unobtainium'
+        }
+    )
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -90,6 +90,18 @@ ServerEvents.recipes(allthemods => {
 
     allthemods.smelting(Item.of('mysticalagriculture:soulstone'), Item.of('mysticalagriculture:soulium_dust'), 0.1)
 
+    allthemods.shaped(
+        Item.of('minecraft:heart_of_the_sea'), [
+            'IDS',
+            'DND',
+            'SDI'
+        ], {
+            'I': 'minecraft:ink_sac',
+            'D': 'justdirethings:celestigem',
+            'S': 'minecraft:prismarine_shard',
+            'N': 'minecraft:nautilus_shell',
+        }
+    )
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/tweaks/tags.js
+++ b/kubejs/server_scripts/tweaks/tags.js
@@ -69,6 +69,8 @@ ServerEvents.tags('item', allthemods => {
         '#c:dusts/vibranium_allthemodium_alloy',
     ])
 
+    allthemods.add('c:gems/benitoite','bigreactors:benitoite_crystal')
+    
     // Ars Elemental Books
     allthemods.add('minecraft:bookshelf_books', 'ars_elemental:air_caster_tome')
     allthemods.add('minecraft:bookshelf_books', 'ars_elemental:fire_caster_tome')


### PR DESCRIPTION
### Config

- adjusts the `darkmode everywhere` inventory button to align better with JEI
- removes the `darkmode everywhere` main menu button

---

### Recipes

Resolves #20 
`minecraft:heart_of_the_sea` 
<img width="378" height="186" alt="kjs_heart_of_the_sea" src="https://github.com/user-attachments/assets/95787299-5745-4fe1-b833-7989fb3cddce" />


Resolves #26 
`forbidden_arcanus:elementarium`
<img width="468" height="348" alt="unknown-recipe" src="https://github.com/user-attachments/assets/73c955de-b97f-427f-aa9a-6ed79b5aeacb" />

`forbidden_arcanus:artisan_relic`
<img width="468" height="348" alt="unknown-recipe_3" src="https://github.com/user-attachments/assets/54962c56-4104-4bbe-beee-0e348dfb1ccd" />

`forbidden_arcanus:divine_pact`
<img width="468" height="348" alt="unknown-recipe_2" src="https://github.com/user-attachments/assets/8b078ecb-110a-420f-92db-822bf1a4fb9d" />

Resolves #28 
`bigreactors:benitoite_crystal`
<img width="480" height="282" alt="industrialforegoing_laser_drill_ore_gems_benitoite" src="https://github.com/user-attachments/assets/b82fd2ea-c285-4686-910e-4208c075e00d" />

Resolves #38 
`allthemodium:allthemodium_upgrade_smithing_template`
`allthemodium:vibranium_upgrade_smithing_template`
`allthemodium:unobtainium_upgrade_smithing_template`
(all following the same pattern)
<img width="378" height="186" alt="kjs_allthemodium_allthemodium_upgrade_smithing_template" src="https://github.com/user-attachments/assets/5e75d282-09c9-4798-b32c-3d4ac03e2e2d" />

---

### Conflicts

Resolves #70 - `enderio:wood_gear`
Resolves #72 - `handcrafted:wood_plate`
Resolves #73 - `handcrafted:hammer`
Resolves #74 - `mcwwindows:bamboo_shutter`
Resolves #80 - Remove conflicting recipes
