### PR TITLE
feat: add more heat options for crucibles

### DIFF
--- a/kubejs/data/exdeorum/kubejs/recipe/crucible_heat_sources/sheol_fire.json
+++ b/kubejs/data/exdeorum/kubejs/recipe/crucible_heat_sources/sheol_fire.json
@@ -1,0 +1,7 @@
+{
+  "type": "exdeorum:crucible_heat_source",
+  "block_predicate": {
+    "block": "oritech:still_sheol_fire_block"
+  },
+  "heat_value": 30
+}

--- a/kubejs/data/exdeorum/kubejs/recipe/crucible_heat_sources/soul_lava.json
+++ b/kubejs/data/exdeorum/kubejs/recipe/crucible_heat_sources/soul_lava.json
@@ -1,0 +1,7 @@
+{
+  "type": "exdeorum:crucible_heat_source",
+  "block_predicate": {
+    "block": "allthemodium:soul_lava"
+  },
+  "heat_value": 80
+}


### PR DESCRIPTION
30x for Sheol fire from Oritech => Obtained by refining lava
80x for Soul Lava => Always is an OP thing so might as well be here as well

I do think mek heater block should be nerfed down to 40 and sheol fire should be up at 60 since it takes more progression
