### PR TITLE
Port resin block recipe from ATM 10

### DIFF
--- a/kubejs/server_scripts/mods/exdeorum/exdeorum.js
+++ b/kubejs/server_scripts/mods/exdeorum/exdeorum.js
@@ -217,8 +217,10 @@ ServerEvents.recipes(allthemods => {
     ]);
 
     // Crucible heating blocks
-    allthemods.recipes.exdeorum.crucible_heat_source({ block_tag: '#c:storage_blocks/uranium' }, 20);
+    allthemods.recipes.exdeorum.crucible_heat_source({ block_tag: 'alltheores:uranium' }, 20);
     allthemods.recipes.exdeorum.crucible_heat_source({ block: 'mekanism:superheating_element' }, 60);
+    allthemods.recipes.exdeorum.crucible_heat_source({block: 'oritech:still_sheol_fire_block'}, 30);
+    allthemods.recipes.exdeorum.crucible_heat_source({block: 'allthemodium:soul_lava'}, 80);
 
     // Hammer
     allthemods.remove({ type: 'exdeorum:compressed_hammer'})

--- a/kubejs/server_scripts/mods/integrated_dynamics/recipes.js
+++ b/kubejs/server_scripts/mods/integrated_dynamics/recipes.js
@@ -1,0 +1,50 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+  function basin( /** @type {$ItemStack_} */ output, /** @type {$FluidStack_} */ input, /** @type {number} */ duration) {
+    let fluidStack = Fluid.of(input)
+    let itemStack = Item.of(output)
+    allthemods.custom(
+      {
+        "type": "integrateddynamics:drying_basin",
+        "input_fluid": {
+          "id": fluidStack.id,
+          "amount": fluidStack.amount
+        },
+        "duration": duration || 300,
+        "output_item": {
+          "id": itemStack.id,
+          "count": itemStack.count
+        }
+      }
+    )
+  }
+
+  function mechanicalBasin( /** @type {$ItemStack_} */ output, /** @type {$FluidStack_} */ input, /** @type {number} */ duration) {
+    let fluidStack = Fluid.of(input)
+    let itemStack = Item.of(output)
+    allthemods.custom(
+      {
+        "type": "integrateddynamics:mechanical_drying_basin",
+        "input_fluid": {
+          "id": fluidStack.id,
+          "amount": fluidStack.amount
+        },
+        "duration": duration || 30,
+        "output_item": {
+          "id": itemStack.id,
+          "count": itemStack.count
+        }
+      }
+    )
+  }
+
+  //basin(output, input, duration)
+  basin('xycraft_machines:resin_block', "1B x xycraft_machines:resin")
+  //mechanicalBasin(output, input, duration)
+  mechanicalBasin('xycraft_machines:resin_block', "1B x xycraft_machines:resin")  
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
It is used in early game as a slime farm
Also removed all the extra uranium block variants since they only clog the JEI
Added sheol fire(processed lava) and soul lava to crucible heat sources