### PR TITLE
feat: unify xp fluid to create exp

### DIFF
--- a/kubejs/server_scripts/Unification/xpFluidToExperience.js
+++ b/kubejs/server_scripts/Unification/xpFluidToExperience.js
@@ -1,0 +1,58 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+  function basin( /** @type {$ItemStack_} */ output, /** @type {string} */ fluidName, /** @type {number} */ fluidAmount, /** @type {number} */ duration) {
+    let itemStack = Item.of(output)
+    allthemods.custom(
+      {
+        "type": "integrateddynamics:drying_basin",
+        "input_fluid": {
+          "id": fluidName,
+          "amount": fluidAmount
+        },
+        "duration": duration || 300,
+        "output_item": {
+          "id": itemStack.id,
+          "count": itemStack.count
+        }
+      }
+    )
+  }
+
+  function mechanicalBasin( /** @type {$ItemStack_} */ output, /** @type {string} */ fluidName, /** @type {number} */ fluidAmount, /** @type {number} */ duration) {
+    let itemStack = Item.of(output)
+    allthemods.custom(
+      {
+        "type": "integrateddynamics:mechanical_drying_basin",
+        "input_fluid": {
+          "id": fluidName,
+          "amount": fluidAmount
+        },
+        "duration": duration || 30,
+        "output_item": {
+          "id": itemStack.id,
+          "count": itemStack.count
+        }
+      }
+    )
+  }
+
+  let xpFluid = [
+    'industrialforegoing:essence',
+    'mob_grinding_utils:fluid_xp',
+    'pneumaticcraft:memory_essence',
+    'sophisticatedcore:xp_still',
+    'create_enchantment_industry:experience'
+  ]
+  xpFluid.sort()
+  for (var i in xpFluid) {
+    let currentFluid = xpFluid[i]
+    basin('create:experience_block', currentFluid, 1000)
+    mechanicalBasin('create:experience_block', currentFluid, 1000)
+  }
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+


### PR DESCRIPTION
I was getting into Create a bit and I realized it'd be nice to convert XP fluid(s) into the Create experience.

I'm not sure if this would be wanted, but I wanted to suggest it :) Please feel free to close if not!

<img width="967" height="1207" alt="image" src="https://github.com/user-attachments/assets/aa75ef90-5921-40cc-9797-9c71e9740e2d" />

I did scan through `server.log` with my change and it looks like we should be good.