### PR TITLE
Make Creative Jetpack use Insanium Essence

### DIFF
--- a/kubejs/server_scripts/modpack/atm_star_creative.js
+++ b/kubejs/server_scripts/modpack/atm_star_creative.js
@@ -205,7 +205,8 @@ ServerEvents.recipes(allthemods => {
                 'DED'
             ],
             {
-                A: 'mysticalagradditions:creative_essence',
+                // Changed from Creative Essence to Insanium Essence since Creative Essence is unavailable
+                A: 'mysticalagradditions:insanium_essence',
                 // Changed from alloy block to unobtainium block since alloys may not be available
                 B: 'allthemodium:unobtainium_block',
                 C: 'ironjetpacks:capacitor[ironjetpacks:jetpack_id="ironjetpacks:creative"]',


### PR DESCRIPTION
Since Creative Essence is unobtainable, and is required for the Creative Jetpack, I changed it to use Insanium Essence instead.