### PR TITLE
Removed Sulfuric Acid Bucket from needed Items for Quest Completion

### DIFF
--- a/config/ftbquests/quests/chapters/rust_free_and_oiled.snbt
+++ b/config/ftbquests/quests/chapters/rust_free_and_oiled.snbt
@@ -193,21 +193,11 @@
 				id: "modern_industrialization:sulfuric_acid_bucket"
 			}
 			id: "2A942E4D328160E7"
-			tasks: [
-				{
+			tasks: [{
 					id: "3B4084F656ADF050"
 					item: { count: 1, id: "modern_industrialization:sulfuric_acid_bucket" }
 					type: "item"
-				}
-				{
-					fluid: {
-						amount: 1000
-						id: "modern_industrialization:sulfuric_acid"
-					}
-					id: "785957D4602B376C"
-					type: "fluid"
-				}
-			]
+				}]
 			x: -13.5d
 			y: -10.5d
 		}


### PR DESCRIPTION
Removed Sulfuric Acid (Fluid) since it's redundant and doesn't follow standards set before
Fixing Issue #346 