### PR TITLE
fix: forgot to include JDT XP when unifying

### DIFF
--- a/kubejs/server_scripts/Unification/xpFluidToExperience.js
+++ b/kubejs/server_scripts/Unification/xpFluidToExperience.js
@@ -43,6 +43,7 @@ ServerEvents.recipes(allthemods => {
     'mob_grinding_utils:fluid_xp',
     'pneumaticcraft:memory_essence',
     'sophisticatedcore:xp_still',
+    'justdirethings:xp_fluid_source',
     'create_enchantment_industry:experience'
   ]
   xpFluid.sort()


### PR DESCRIPTION
So I forgot to include JDT XP in my last PR, so I wanted to fix that omission.

<img width="921" height="500" alt="image" src="https://github.com/user-attachments/assets/90f2b320-c470-48f2-9fb3-aacad8e2b7c2" />
