### PR TITLE
Coal Shard: Allow crushing into coal dust into missing machines

### DIFF
--- a/kubejs/server_scripts/mods/actuallyadditions/recipes.js
+++ b/kubejs/server_scripts/mods/actuallyadditions/recipes.js
@@ -24,6 +24,11 @@ ServerEvents.recipes(allthemods => {
 
     // laser(output, input, power)
     aa.laser('occultism:iesnium_ore', 'minecraft:ancient_debris', 50000)
+
+    allthemods.recipes.actuallyadditions.crushing(
+        [{ stack: 'alltheores:coal_dust', chance: 1.0 }],
+        'geore:coal_shard'
+    ).id('allthemods:actuallyadditions/crushing/coal_dust_from_shard')
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.

--- a/kubejs/server_scripts/mods/mekanism/mekanism.js
+++ b/kubejs/server_scripts/mods/mekanism/mekanism.js
@@ -33,4 +33,15 @@ ServerEvents.recipes(allthemods => {
         }
       }).id(`kubejs:mekanism/crushing/${outputs[index].split(':')[1]}`)
     })
+
+    allthemods.custom({
+      type: 'mekanism:crushing',
+      input: {
+        item: 'geore:coal_shard'
+      },
+      output: {
+        id: 'mekanism:dust_coal',
+        count: 1
+      }
+    }).id('allthemods:mekanism/crushing/coal_dust_from_shard')
 })

--- a/kubejs/server_scripts/mods/occultism/recipes.js
+++ b/kubejs/server_scripts/mods/occultism/recipes.js
@@ -10,6 +10,20 @@ ServerEvents.recipes(allthemods => {
     materials.forEach(material => {
         allthemods.remove({id: `occultism:crushing/${material}_dirty_dust_from_clump`})
     })
+
+    allthemods.custom({
+        type: 'occultism:crushing',
+        ingredient: {
+            item: 'geore:coal_shard'
+        },
+        result: {
+            type: 'occultism:item',
+            item: 'mekanism:dust_coal',
+            count: 1
+        },
+        crushing_time: 100,
+        ignore_crushing_multiplier: true
+    }).id('allthemods:occultism/crushing/coal_dust_from_shard')
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -250,6 +250,44 @@ ServerEvents.recipes(allthemods => {
             '#c:storage_blocks/amethyst'
         ]
     )
+
+    allthemods.custom({
+        type: 'immersiveengineering:crusher',
+        energy: 800,
+        input: {
+            item: 'geore:coal_shard'
+        },
+        result: {
+            item: 'mekanism:dust_coal',
+            count: 1
+        },
+        secondaries: []
+    }).id('allthemods:immersiveengineering/crusher/coal_dust_from_shard')
+
+    allthemods.custom({
+      "type": "modern_industrialization:macerator",
+      "eu": 2,
+      "duration": 100,
+      "item_inputs": {
+        "item": "geore:coal_shard",
+        "amount": 1
+      },
+      "item_outputs": {
+        "item": "modern_industrialization:coal_dust",
+        "amount": 1
+      }
+    }).id('allthemods:modern_industrialization/macerator/coal_dust_from_shard')
+
+    allthemods.custom({
+      "type": "industrialforegoing:crusher",
+      "input": {
+        "item": "geore:coal_shard"
+      },
+      "output": {
+        "item": "mekanism:dust_coal",
+        "count": 1
+      }
+    }).id('allthemods:industrialforegoing/crusher/coal_dust_from_shard')
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
This PR Addresses the issue of Coal Dust being craftable in some machines (like the SAG Mill, or Create's crusher) but not in others. Since Coal Shard is a part of coals, it should be crushable just like coal is.