### PR TITLE
Fix RFTools Module Syringe Display in JEI

### DIFF
--- a/kubejs/server_scripts/mods/rftools/recipes.js
+++ b/kubejs/server_scripts/mods/rftools/recipes.js
@@ -1,0 +1,168 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+ServerEvents.recipes(allthemods => {
+	allthemods.remove({ id: `rftoolsutility:flight_module`})
+	allthemods.remove({ id: `rftoolsutility:blindness_module`})
+	allthemods.remove({ id: `rftoolsutility:featherfalling_module`})
+	allthemods.remove({ id: `rftoolsutility:haste_module`})
+	allthemods.remove({ id: `rftoolsutility:glowing_module`})
+	allthemods.remove({ id: `rftoolsutility:luck_module`})
+	allthemods.remove({ id: `rftoolsutility:nightvision_module`})
+	allthemods.remove({ id: `rftoolsutility:noteleport_module`})
+	allthemods.remove({ id: `rftoolsutility:peaceful_module`})
+	allthemods.remove({ id: `rftoolsutility:poison_module`})
+	allthemods.remove({ id: `rftoolsutility:regeneration_module`})
+	allthemods.remove({ id: `rftoolsutility:saturation_module`})
+	allthemods.remove({ id: `rftoolsutility:slowness_module`})
+	allthemods.remove({ id: `rftoolsutility:speed_module`})
+	allthemods.remove({ id: `rftoolsutility:waterbreathing_module`})
+	allthemods.remove({ id: `rftoolsutility:weakness_module`})
+	// Fix Syringe Display
+     allthemods.shaped(Item.of('rftoolsutility:flight_module', 1), [
+        'DUD',
+        'DND',
+        'DPD'
+    ], {
+        D: 'minecraft:ghast_tear',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:ghast"}]',
+        N: 'rftoolsutility:moduleplus_template',
+		P: 'rftoolsbase:infused_enderpearl'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:blindness_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:black_dye',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:squid"}]',
+        N: 'rftoolsutility:moduleplus_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:featherfalling_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:feather',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:chicken"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:haste_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:redstone',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:pillager"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:glowing_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:glowstone',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:creeper"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:luck_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:quartz',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:cat"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:nightvision_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:glowstone',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:drowned"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:noteleport_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:ender_pearl',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:enderman"}]',
+        N: 'rftoolsutility:moduleplus_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:peaceful_module', 1), [
+        'IUI',
+        'DND',
+        'IDI'
+    ], {
+        D: 'rftoolsbase:infused_enderpearl',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:iron_golem"}]',
+        N: 'rftoolsutility:moduleplus_template',
+		I: 'minecraft:iron_block'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:poison_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:poisonous_potato',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:cave_spider"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:regeneration_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:golden_apple',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:witch"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:saturation_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:rotten_flesh',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:zombie"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:slowness_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:string',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:turtle"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:speed_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:powered_rail',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:wolf"}]',
+        N: 'rftoolsutility:module_template'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:waterbreathing_module', 1), [
+        'PUP',
+        'DND',
+        'PDP'
+    ], {
+        D: 'rftoolsbase:infused_enderpearl',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:guardian"}]',
+        N: 'rftoolsutility:moduleplus_template',
+		P: 'minecraft:prismarine'
+    });
+	allthemods.shaped(Item.of('rftoolsutility:weakness_module', 1), [
+        'DUD',
+        'DND',
+        'DDD'
+    ], {
+        D: 'minecraft:cactus',
+        U: 'rftoolsutility:syringe[rftoolsutility:syringe_data={level:10,mob:"minecraft:piglin"}]',
+        N: 'rftoolsutility:module_template'
+    });
+});


### PR DESCRIPTION
This aims to fix the recipes for the various modules in RFToolsUtility displaying an empty syringe in JEI by removing the original recipes then creating an exact duplicate with KubeJS. An example of this can be seen here, with the Flight Module.
<img width="441" height="204" alt="image" src="https://github.com/user-attachments/assets/3e0acfc4-8a44-438e-9a59-84e93eb4342b" />
<img width="579" height="384" alt="image" src="https://github.com/user-attachments/assets/b010d7b7-e075-4dc2-bf6d-361678b1ba45" />
