### PR TITLE
fix: dust to be used for clay

### DIFF
--- a/kubejs/server_scripts/tweaks/allthecompressed.js
+++ b/kubejs/server_scripts/tweaks/allthecompressed.js
@@ -69,7 +69,7 @@ ServerEvents.recipes(allthemods => {
         allthemods.smelting(`allthecompressed:stone_${i}x`, `allthecompressed:cobblestone_${i}x`)
         allthemods.smelting(`allthecompressed:glass_${i}x`, `allthecompressed:sand_${i}x`)
 
-        allthemods.recipes.exdeorum.barrel_mixing(`allthecompressed:clay_${i}x`, `allthecompressed:sand_${i}x`, '1000x minecraft:water')
+        allthemods.recipes.exdeorum.barrel_mixing(`allthecompressed:clay_${i}x`, `allthecompressed:dust_${i}x`, '1000x minecraft:water')
     } 
 })
 


### PR DESCRIPTION
Standard ex deorum recipes use dust to clay conversion, the kubejs recipe was using compressed sand

Fixed to now use compressed dust