### PR TITLE
Remove Berserker's Fury and Miner's Fervor

### DIFF
--- a/kubejs/data/apothic_enchanting/enchantment/berserkers_fury.json
+++ b/kubejs/data/apothic_enchanting/enchantment/berserkers_fury.json
@@ -1,0 +1,110 @@
+{
+    "neoforge:conditions":[{"type":"neoforge:false"}],
+    "anvil_cost": 10,
+    "description": {
+        "color": "dark_red",
+        "translate": "enchantment.apothic_enchanting.berserkers_fury"
+    },
+    "effects": {
+        "apothic_enchanting:berserking": {
+            "cooldown": [
+                {
+                    "effect": {
+                        "type": "minecraft:add",
+                        "value": 900.0
+                    }
+                }
+            ],
+            "hp_cost": [
+                {
+                    "effect": {
+                        "type": "minecraft:add",
+                        "value": {
+                            "type": "apothic_enchanting:exponential",
+                            "base": 2.5
+                        }
+                    }
+                }
+            ],
+            "mob_effects": [
+                {
+                    "effect": {
+                        "amplifier": [
+                            {
+                                "type": "minecraft:add",
+                                "value": {
+                                    "type": "minecraft:linear",
+                                    "base": 0.0,
+                                    "per_level_above_first": 1.0
+                                }
+                            }
+                        ],
+                        "duration": [
+                            {
+                                "type": "minecraft:add",
+                                "value": 500.0
+                            }
+                        ],
+                        "mob_effect": "minecraft:resistance"
+                    }
+                },
+                {
+                    "effect": {
+                        "amplifier": [
+                            {
+                                "type": "minecraft:add",
+                                "value": {
+                                    "type": "minecraft:linear",
+                                    "base": 0.0,
+                                    "per_level_above_first": 1.0
+                                }
+                            }
+                        ],
+                        "duration": [
+                            {
+                                "type": "minecraft:add",
+                                "value": 500.0
+                            }
+                        ],
+                        "mob_effect": "minecraft:strength"
+                    }
+                },
+                {
+                    "effect": {
+                        "amplifier": [
+                            {
+                                "type": "minecraft:add",
+                                "value": {
+                                    "type": "minecraft:linear",
+                                    "base": 0.0,
+                                    "per_level_above_first": 1.0
+                                }
+                            }
+                        ],
+                        "duration": [
+                            {
+                                "type": "minecraft:add",
+                                "value": 500.0
+                            }
+                        ],
+                        "mob_effect": "minecraft:speed"
+                    }
+                }
+            ]
+        }
+    },
+    "max_cost": {
+        "base": 200,
+        "per_level_above_first": 0
+    },
+    "max_level": 3,
+    "min_cost": {
+        "base": 50,
+        "per_level_above_first": 40
+    },
+    "slots": [
+        "chest"
+    ],
+    "supported_items": "#minecraft:enchantable/chest_armor",
+    "weight": 1
+}

--- a/kubejs/data/apothic_enchanting/enchantment/miners_fervor.json
+++ b/kubejs/data/apothic_enchanting/enchantment/miners_fervor.json
@@ -1,0 +1,30 @@
+{
+    "neoforge:conditions":[{"type":"neoforge:false"}],
+    "anvil_cost": 10,
+    "description": {
+        "color": "dark_purple",
+        "translate": "enchantment.apothic_enchanting.miners_fervor"
+    },
+    "effects": {
+        "apothic_enchanting:miners_fervor": {
+            "type": "minecraft:linear",
+            "base": 12.0,
+            "per_level_above_first": 4.5
+        }
+    },
+    "exclusive_set": "minecraft:efficiency",
+    "max_cost": {
+        "base": 200,
+        "per_level_above_first": 0
+    },
+    "max_level": 5,
+    "min_cost": {
+        "base": 45,
+        "per_level_above_first": 30
+    },
+    "slots": [
+        "mainhand"
+    ],
+    "supported_items": "#minecraft:enchantable/mining",
+    "weight": 2
+}


### PR DESCRIPTION
I saw several issues relating to these enchantments, namely:
- Miner's Fervor preventing being able to mine Unobtainium
- Berserker's Fury being a common cause for some people taking more damage than usual without realizing why, including deaths from a "Corrupted Enchantment"