### PR TITLE
immersive engineering bayonet recipe fix

### DIFF
--- a/kubejs/server_scripts/mods/immersive_engineering/Compatibility.js
+++ b/kubejs/server_scripts/mods/immersive_engineering/Compatibility.js
@@ -1,0 +1,11 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+
+  allthemods.replaceInput({ id: 'immersiveengineering:crafting/toolupgrade_revolver_bayonet' }, 'immersiveengineering:sword_steel', 'mekanismtools:steel_sword')
+  
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/mods/immersive_engineering/Compatibility.js
+++ b/kubejs/server_scripts/mods/immersive_engineering/Compatibility.js
@@ -1,4 +1,4 @@
-// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
 ServerEvents.recipes(allthemods => {
@@ -7,5 +7,5 @@ ServerEvents.recipes(allthemods => {
   
 })
 
-// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
replaces IE Steel Sword with Mek Steel Sword in the IE Bayonet recipe
Fixes #244

Grabbed the fix from the ATM-10 repo ([ATM-10 #2735](https://github.com/AllTheMods/ATM-10/issues/2735))




