### PR TITLE
feat: add ATM paxels

### DIFF
--- a/kubejs/server_scripts/mods/draconic_evolution/alloy_axe.js
+++ b/kubejs/server_scripts/mods/draconic_evolution/alloy_axe.js
@@ -1,40 +1,40 @@
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
-ServerEvents.recipes(allthemods => {
-    allthemods
+ServerEvents.recipes((allthemods) => {
+  allthemods
     .custom({
-        "type": "draconicevolution:fusion_crafting",
-        "catalyst": {
-          "item": "minecraft:netherite_axe"
-        },
-        "ingredients": [
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/allthemodium"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/vibranium"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/unobtainium"
-            }
+      type: "draconicevolution:fusion_crafting",
+      catalyst: {
+        item: "minecraft:netherite_axe"
+      },
+      ingredients: [
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/allthemodium"
           }
-        ],
-        "result": {
-          "count": 1,
-          "id": "allthemodium:alloy_axe"
         },
-        "techLevel": "draconic",
-        "totalEnergy": 32000000
-      })
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/vibranium"
+          }
+        },
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/unobtainium"
+          }
+        }
+      ],
+      result: {
+        count: 1,
+        id: "allthemodium:alloy_axe"
+      },
+      techLevel: "draconic",
+      totalEnergy: 32000000
+    })
     .id("allthemodsmodium:draconic_evolution/alloy_axe")
 })
 

--- a/kubejs/server_scripts/mods/draconic_evolution/alloy_paxel.js
+++ b/kubejs/server_scripts/mods/draconic_evolution/alloy_paxel.js
@@ -1,46 +1,46 @@
 ﻿// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
-ServerEvents.recipes(allthemods => {
-    allthemods
+ServerEvents.recipes((allthemods) => {
+  allthemods
     .custom({
-        "type": "draconicevolution:fusion_crafting",
-        "catalyst": {
-          "item": "justdirethings:eclipsealloy_paxel"
-        },
-        "ingredients": [
-          {
-            "consume": true,
-            "ingredient": {
-              "item": "allthemodium:alloy_sword"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "item": "allthemodium:alloy_pick"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "item": "allthemodium:alloy_axe"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "item": "allthemodium:alloy_shovel"
-            }
+      type: "draconicevolution:fusion_crafting",
+      catalyst: {
+        item: "justdirethings:eclipsealloy_paxel"
+      },
+      ingredients: [
+        {
+          consume: true,
+          ingredient: {
+            item: "allthemodium:alloy_sword"
           }
-        ],
-        "result": {
-          "count": 1,
-          "id": "allthemodium:alloy_paxel"
         },
-        "techLevel": "chaotic",
-        "totalEnergy": 128000000
-      })
+        {
+          consume: true,
+          ingredient: {
+            item: "allthemodium:alloy_pick"
+          }
+        },
+        {
+          consume: true,
+          ingredient: {
+            item: "allthemodium:alloy_axe"
+          }
+        },
+        {
+          consume: true,
+          ingredient: {
+            item: "allthemodium:alloy_shovel"
+          }
+        }
+      ],
+      result: {
+        count: 1,
+        id: "allthemodium:alloy_paxel"
+      },
+      techLevel: "chaotic",
+      totalEnergy: 128000000
+    })
     .id("allthemodsmodium:draconic_evolution/alloy_paxel")
 })
 

--- a/kubejs/server_scripts/mods/draconic_evolution/alloy_pick.js
+++ b/kubejs/server_scripts/mods/draconic_evolution/alloy_pick.js
@@ -1,40 +1,40 @@
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
-ServerEvents.recipes(allthemods => {
-    allthemods
+ServerEvents.recipes((allthemods) => {
+  allthemods
     .custom({
-        "type": "draconicevolution:fusion_crafting",
-        "catalyst": {
-          "item": "minecraft:netherite_pickaxe"
-        },
-        "ingredients": [
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/allthemodium"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/vibranium"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/unobtainium"
-            }
+      type: "draconicevolution:fusion_crafting",
+      catalyst: {
+        item: "minecraft:netherite_pickaxe"
+      },
+      ingredients: [
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/allthemodium"
           }
-        ],
-        "result": {
-          "count": 1,
-          "id": "allthemodium:alloy_pick"
         },
-        "techLevel": "draconic",
-        "totalEnergy": 32000000
-      })
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/vibranium"
+          }
+        },
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/unobtainium"
+          }
+        }
+      ],
+      result: {
+        count: 1,
+        id: "allthemodium:alloy_pick"
+      },
+      techLevel: "draconic",
+      totalEnergy: 32000000
+    })
     .id("allthemodsmodium:draconic_evolution/alloy_pick")
 })
 

--- a/kubejs/server_scripts/mods/draconic_evolution/alloy_shovel.js
+++ b/kubejs/server_scripts/mods/draconic_evolution/alloy_shovel.js
@@ -1,40 +1,40 @@
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
-ServerEvents.recipes(allthemods => {
-    allthemods
+ServerEvents.recipes((allthemods) => {
+  allthemods
     .custom({
-        "type": "draconicevolution:fusion_crafting",
-        "catalyst": {
-          "item": "minecraft:netherite_shovel"
-        },
-        "ingredients": [
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/allthemodium"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/vibranium"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/unobtainium"
-            }
+      type: "draconicevolution:fusion_crafting",
+      catalyst: {
+        item: "minecraft:netherite_shovel"
+      },
+      ingredients: [
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/allthemodium"
           }
-        ],
-        "result": {
-          "count": 1,
-          "id": "allthemodium:alloy_shovel"
         },
-        "techLevel": "draconic",
-        "totalEnergy": 32000000
-      })
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/vibranium"
+          }
+        },
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/unobtainium"
+          }
+        }
+      ],
+      result: {
+        count: 1,
+        id: "allthemodium:alloy_shovel"
+      },
+      techLevel: "draconic",
+      totalEnergy: 32000000
+    })
     .id("allthemodsmodium:draconic_evolution/alloy_shovel")
 })
 

--- a/kubejs/server_scripts/mods/draconic_evolution/alloy_sword.js
+++ b/kubejs/server_scripts/mods/draconic_evolution/alloy_sword.js
@@ -1,40 +1,40 @@
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10: To the Sky.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
-ServerEvents.recipes(allthemods => {
-    allthemods
+ServerEvents.recipes((allthemods) => {
+  allthemods
     .custom({
-        "type": "draconicevolution:fusion_crafting",
-        "catalyst": {
-          "item": "minecraft:netherite_sword"
-        },
-        "ingredients": [
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/allthemodium"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/vibranium"
-            }
-          },
-          {
-            "consume": true,
-            "ingredient": {
-              "tag": "c:ingots/unobtainium"
-            }
+      type: "draconicevolution:fusion_crafting",
+      catalyst: {
+        item: "minecraft:netherite_sword"
+      },
+      ingredients: [
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/allthemodium"
           }
-        ],
-        "result": {
-          "count": 1,
-          "id": "allthemodium:alloy_sword"
         },
-        "techLevel": "draconic",
-        "totalEnergy": 32000000
-      })
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/vibranium"
+          }
+        },
+        {
+          consume: true,
+          ingredient: {
+            tag: "c:ingots/unobtainium"
+          }
+        }
+      ],
+      result: {
+        count: 1,
+        id: "allthemodium:alloy_sword"
+      },
+      techLevel: "draconic",
+      totalEnergy: 32000000
+    })
     .id("allthemodsmodium:draconic_evolution/alloy_sword")
 })
 


### PR DESCRIPTION
So, I wanted the paxel in and I suggested DE for the means, so here's my stab at it.  Honestly, this feels too easy, so I am curious what things I should tweak.  
My thoughts:
* I am not using the alloys (since we don't have recipes for those either) just yet either.  I could add the alloy recipes here in this PR and we could update the DE specific recipes accordingly? I was thinking productive metalworks (needing soul lava) for that, but I didn't want to overstep.
* These recipes feel too easy.  I was thinking of tossing in some required draconic cores or chaotic cores (alloy-tiered tools vs paxel).  What do y'all think?

Cheers,
Kevin

## Screenshots
<img width="727" height="645" alt="image" src="https://github.com/user-attachments/assets/498be93b-5a28-4dfb-87c8-22265d6a76a5" />

<img width="682" height="647" alt="image" src="https://github.com/user-attachments/assets/678b0683-f6f6-40d2-9e70-39119881c9c3" />

<img width="674" height="631" alt="image" src="https://github.com/user-attachments/assets/9dbc5980-25af-424f-9ad5-7a496117b693" />

<img width="731" height="627" alt="image" src="https://github.com/user-attachments/assets/07afaf51-68aa-4009-ac62-b88f2a68477e" />

<img width="734" height="631" alt="image" src="https://github.com/user-attachments/assets/f8aaac6c-5f71-49ff-b6ed-0e24ea10b74c" />

