### PR TITLE
Add a whitelist for FTBChunks

### DIFF
--- a/kubejs/server_scripts/ftbchunks_whitelist.js
+++ b/kubejs/server_scripts/ftbchunks_whitelist.js
@@ -1,0 +1,4 @@
+ServerEvents.tags('block', event => {
+    event.add('ftbchunks:interact_whitelist', 'epitaphs:grave')
+    event.add('ftbchunks:edit_whitelist', 'epitaphs:grave')
+})


### PR DESCRIPTION
Currently only contains the grave mod. Should allow collecting graves even if they are in somone's claim.