### PR TITLE
Apotheosis Loot Category Overrides

### DIFF
--- a/kubejs/data/apotheosis/data_maps/item/loot_category_overrides.json
+++ b/kubejs/data/apotheosis/data_maps/item/loot_category_overrides.json
@@ -1,9 +1,9 @@
 {
-    "values": {
-        "allthemodium:alloy_paxel": "apotheosis:breaker",
-        "silentgear:mace": "apotheosis:melee_weapon",
-		"silentgear:axe": "apotheosis:melee_weapon",
-		"draconicevolution:draconic_staff": "apotheosis:melee_weapon",
-		"draconicevolution:chaotic_staff": "apotheosis:melee_weapon"
-    }
+  "values": {
+    "allthemodium:alloy_paxel": "apotheosis:breaker",
+    "silentgear:mace": "apotheosis:melee_weapon",
+    "silentgear:axe": "apotheosis:melee_weapon",
+    "draconicevolution:draconic_staff": "apotheosis:melee_weapon",
+    "draconicevolution:chaotic_staff": "apotheosis:melee_weapon"
+  }
 }


### PR DESCRIPTION
Ported from ATM10, plus added Staff of Power overrides
Addresses the following items:
Allthemodium Alloy Paxel: Breaker instead of Melee Weapon
Silent Gear Maces and Axes: Melee Weapon
Draconic and Chaotic Staff of Power: Melee Weapon (I know, it's a paxel, but I'm personally biased towards having it be a weapon, especially with ATM Alloy Paxel being made a Breaker. If you want it to be a Breaker instead, either let me know or make a commit to override this PR or something)