### PR TITLE
fix: Add Feral Flare Invisible Lights to minecraft:replaceable

### DIFF
--- a/kubejs/server_scripts/tweaks/tags.js
+++ b/kubejs/server_scripts/tweaks/tags.js
@@ -49,7 +49,7 @@ ServerEvents.tags("block", (allthemods) => {
   allthemods.add("justdirethings:tick_speed_deny", "#allthemods:tick_acceleration_blacklist")
   allthemods.add("tiab:un_acceleratable", "#allthemods:tick_acceleration_blacklist")
   //allthemods.add('industrialforegoingsouls:cant_accelerate', '#allthemods:tick_acceleration_blacklist')
-  
+
   // Fix Jank with Feral Flares and Enchanting
   allthemods.add("minecraft:replaceable", "torchmaster:invisible_light")
 })


### PR DESCRIPTION
Fixes issues involving Feral Flare Lanterns blocking Enchanting Tables
Turning this
<img width="908" height="785" alt="image" src="https://github.com/user-attachments/assets/98606387-5b78-4a3e-8b0e-82615e607125" />
Into this
<img width="1474" height="851" alt="image" src="https://github.com/user-attachments/assets/91373cb8-b62f-4d24-880a-a386cb9c5ee1" />
