### PR TITLE
Oritech Loot Category Overrides

### DIFF
--- a/kubejs/data/apotheosis/data_maps/item/loot_category_overrides.json
+++ b/kubejs/data/apotheosis/data_maps/item/loot_category_overrides.json
@@ -1,11 +1,11 @@
 {
-    "values": {
-        "allthemodium:alloy_paxel": "apotheosis:breaker",
-        "silentgear:mace": "apotheosis:melee_weapon",
-		"silentgear:axe": "apotheosis:melee_weapon",
-		"oritech:promethium_pickaxe": "apotheosis:breaker",
-		"oritech:hand_drill": "apotheosis:breaker",
-		"draconicevolution:draconic_staff": "apotheosis:melee_weapon",
-		"draconicevolution:chaotic_staff": "apotheosis:melee_weapon"
-    }
+  "values": {
+    "allthemodium:alloy_paxel": "apotheosis:breaker",
+    "silentgear:mace": "apotheosis:melee_weapon",
+    "silentgear:axe": "apotheosis:melee_weapon",
+    "oritech:promethium_pickaxe": "apotheosis:breaker",
+    "oritech:hand_drill": "apotheosis:breaker",
+    "draconicevolution:draconic_staff": "apotheosis:melee_weapon",
+    "draconicevolution:chaotic_staff": "apotheosis:melee_weapon"
+  }
 }


### PR DESCRIPTION
Added Oritech Prometheum Pickaxe and Hand Drill to Breaker category with Apotheosis. This makes it use pickaxe affixes rather than melee weapon affixes