### PR TITLE
Add compacting recipes for tiny coal, ender pearl fragments

### DIFF
--- a/kubejs/server_scripts/mods/functionalstorage/recipes.js
+++ b/kubejs/server_scripts/mods/functionalstorage/recipes.js
@@ -18,6 +18,11 @@ ServerEvents.recipes((allthemods) => {
       .id(`allthemods:functionalstorage/compacting/${lower.id.split(":")[1]}_to_${higher.id.split(":")[1]}`)
   }
 
+  compact(Item.of("utilitarian:tiny_charcoal", 8), Item.of("minecraft:charcoal"))
+  compact(Item.of("utilitarian:tiny_coal", 8), Item.of("minecraft:coal"))
+
+  compact(Item.of("forbidden_arcanus:ender_pearl_fragment", 4), Item.of("minecraft:ender_pearl"))
+
   compact(Item.of("exdeorum:stone_pebble", 4), Item.of("minecraft:cobblestone"))
   compact(Item.of("exdeorum:diorite_pebble", 4), Item.of("minecraft:diorite"))
   compact(Item.of("exdeorum:andesite_pebble", 4), Item.of("minecraft:andesite"))


### PR DESCRIPTION
This copies the compacting recipes for ATM 10 that aren't available in ATM 10 TTS, and also adds an extra recipe for compacting ender pearl fragments.