### PR TITLE
More compacting recipe changes

### DIFF
--- a/kubejs/data/megacells/data_maps/item/compression_overrides.json
+++ b/kubejs/data/megacells/data_maps/item/compression_overrides.json
@@ -1,10 +1,91 @@
 {
   "values": {
+    "alltheores:steel_nugget": {
+      "variant": "alltheores:steel_ingot"
+    },
+    "exdeorum:aluminum_ore_chunk": {
+      "variant": "alltheores:aluminum_ore"
+    },
+    "exdeorum:andesite_pebble": {
+      "variant": "minecraft:andesite"
+    },
+    "exdeorum:basalt_pebble": {
+      "variant": "minecraft:basalt"
+    },
+    "exdeorum:blackstone_pebble": {
+      "variant": "minecraft:blackstone"
+    },
+    "exdeorum:calcite_pebble": {
+      "variant": "minecraft:calcite"
+    },
+    "exdeorum:copper_ore_chunk": {
+      "variant": "minecraft:copper_ore"
+    },
+    "exdeorum:deepslate_pebble": {
+      "variant": "minecraft:cobbled_deepslate"
+    },
+    "exdeorum:diorite_pebble": {
+      "variant": "minecraft:diorite"
+    },
+    "exdeorum:gold_ore_chunk": {
+      "variant": "minecraft:gold_ore"
+    },
+    "exdeorum:granite_pebble": {
+      "variant": "minecraft:granite"
+    },
+    "exdeorum:iron_ore_chunk": {
+      "variant": "minecraft:iron_ore"
+    },
+    "exdeorum:lead_ore_chunk": {
+      "variant": "alltheores:lead_ore"
+    },
+    "exdeorum:nickel_ore_chunk": {
+      "variant": "alltheores:nickel_ore"
+    },
+    "exdeorum:osmium_ore_chunk": {
+      "variant": "alltheores:osmium_ore"
+    },
+    "exdeorum:platinum_ore_chunk": {
+      "variant": "alltheores:platinum_ore"
+    },
+    "exdeorum:silver_ore_chunk": {
+      "variant": "alltheores:silver_ore"
+    },
+    "exdeorum:stone_pebble": {
+      "variant": "minecraft:cobblestone"
+    },
+    "exdeorum:tin_ore_chunk": {
+      "variant": "alltheores:tin_ore"
+    },
+    "exdeorum:tuff_pebble": {
+      "variant": "minecraft:tuff"
+    },
+    "exdeorum:uranium_ore_chunk": {
+      "variant": "alltheores:uranium_ore"
+    },
+    "exdeorum:zinc_ore_chunk": {
+      "variant": "alltheores:zinc_ore"
+    },
     "oritech:biosteel_ingot": {
       "variant": "NONE"
     },
-    "alltheores:steel_nugget": {
-      "variant": "alltheores:steel_ingot"
+    "pickletweaks:charoal_piece": {
+      "variant": "NONE"
+    },
+    "pickletweaks:coal_piece": {
+      "variant": "NONE"
+    },
+    "productivebees:draconic_dust": {
+      "variant": "productivebees:draconic_chunk"
+    },
+    "utilitarian:tiny_charcoal": {
+      "variant": "minecraft:charcoal"
+    },
+    "utilitarian:tiny_coal": {
+      "variant": "minecraft:coal"
+    },
+    "wstweaks:fragment": {
+      "variant": "minecraft:wither_skeleton_skull"
     }
   }
 }

--- a/kubejs/server_scripts/mods/functionalstorage/recipes.js
+++ b/kubejs/server_scripts/mods/functionalstorage/recipes.js
@@ -21,7 +21,12 @@ ServerEvents.recipes((allthemods) => {
   compact(Item.of("utilitarian:tiny_charcoal", 8), Item.of("minecraft:charcoal"))
   compact(Item.of("utilitarian:tiny_coal", 8), Item.of("minecraft:coal"))
 
+  compact(Item.of("minecraft:pointed_dripstone", 4), Item.of("minecraft:dripstone_block"))
+
+  compact(Item.of("extendedae:entro_shard", 8), Item.of("extendedae:entro_crystal"))
   compact(Item.of("forbidden_arcanus:ender_pearl_fragment", 4), Item.of("minecraft:ender_pearl"))
+  compact(Item.of("productivebees:draconic_dust", 9), Item.of("productivebees:draconic_chunk"))
+  compact(Item.of("wstweaks:fragment", 9), Item.of("minecraft:wither_skeleton_skull"))
 
   compact(Item.of("exdeorum:stone_pebble", 4), Item.of("minecraft:cobblestone"))
   compact(Item.of("exdeorum:diorite_pebble", 4), Item.of("minecraft:diorite"))


### PR DESCRIPTION
* Synchronises MEGACells compacting recipes with functional storage compacting.
* Adds compacting recipes for pointed dripstone to dripstone blocks, entro shards to entro crystals, draconic dust to draconic chunks, and skull fragments to wither skeleton skulls.
* Fixes an issue with MEGACells compacting where tiny coal was compacting into coal geores instead of coal.
* Due to a limitation in the MEGACells mod, compacting for ender pearl fragments, and entro shards is still not supported, but available for functional storage.