### PR TITLE
Update block_gen.js

### DIFF
--- a/kubejs/server_scripts/mods/cobble_galore/block_gen.js
+++ b/kubejs/server_scripts/mods/cobble_galore/block_gen.js
@@ -12,8 +12,7 @@ ServerEvents.recipes((allthemods) => {
       right: {
         Name: right
       },
-      speed: speed || 1,
-      consumeRight: true
+      speed: speed || 1
     }
 
     if (below) {


### PR DESCRIPTION
Fix: remove consumeRight flag from blockgen recipes

Prevent right-side fluid from being consumed on each generation cycle