### PR TITLE
Add ATM10A on README modpack list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ When reporting an issue, please follow the templates!
 + [![All the Magic Arcana](http://cf.way2muchnoise.eu/1190911.svg "ATMA") All The Magic - Arcana - ATMA](https://www.curseforge.com/minecraft/modpacks/all-the-magic-arcana)
 + [![All the Mods 10 Lite](http://cf.way2muchnoise.eu/1298400.svg "ATM10L") All The Mods 10 Lite - ATM10L](https://www.curseforge.com/minecraft/modpacks/all-the-mods-10-lite)
 + [![All the Mons](http://cf.way2muchnoise.eu/1356598.svg "ATMons") All The Mons - ATMons](https://www.curseforge.com/minecraft/modpacks/all-the-mons)
++ [![All The Mods 10 - Aeronautics Edition](http://cf.way2muchnoise.eu/1644918.svg "ATM10A") All The Mods 10 - Aeronautics Edition - ATM10A](https://www.curseforge.com/minecraft/modpacks/all-the-mods-10-aeronautics)
 + [![All The Mods 11](https://cf.way2muchnoise.eu/1148445.svg "ATM11") All The Mods 11 - ATM11](https://www.curseforge.com/minecraft/modpacks/all-the-mods-11)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # All-the-mods-10-Sky
-======
+
 All the mods skyblock pack for 1.21.1 NeoForge
 
 Does "All The Mods" *really* contain ALL THE MODS? No, of course not.


### PR DESCRIPTION
Adds ATM10A to the modpack list. The ATM10A abbreviation was confirmed in advance with oly2o6.